### PR TITLE
Dockerfile based on Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine
+LABEL maintainer "Dave Curylo <dave@curylo.org>, Michael Hendricks <michael@ndrix.org>"
+RUN apk --update add --no-cache curl libarchive readline pcre gmp libressl libedit zlib db unixodbc
+RUN apk --update add --no-cache --virtual build-dependencies bash alpine-sdk autoconf libarchive-dev gmp-dev pcre-dev readline-dev libedit-dev libressl-dev zlib-dev db-dev unixodbc-dev linux-headers \
+    && apk add geos-dev --update-cache --virtual build-dependencies --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted \
+    && git clone https://github.com/SWI-Prolog/swipl-devel \
+    && cd swipl-devel && ./prepare --yes && ./configure && make && make install \
+    && cd packages && ./configure && make && make install \
+    && apk del build-dependencies \
+    && cd ../.. && rm -rf swipl-devel
+CMD ["swipl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM alpine
 LABEL maintainer "Dave Curylo <dave@curylo.org>, Michael Hendricks <michael@ndrix.org>"
-RUN apk --update add --no-cache curl libarchive readline pcre gmp libressl libedit zlib db unixodbc
-RUN apk --update add --no-cache --virtual build-dependencies bash alpine-sdk autoconf libarchive-dev gmp-dev pcre-dev readline-dev libedit-dev libressl-dev zlib-dev db-dev unixodbc-dev linux-headers \
+RUN apk --update add --no-cache curl libarchive readline pcre gmp libressl libedit zlib db unixodbc libuuid \
+    && apk --update add --no-cache --virtual build-dependencies bash alpine-sdk autoconf libarchive-dev gmp-dev pcre-dev readline-dev libedit-dev libressl-dev zlib-dev db-dev unixodbc-dev linux-headers \
     && apk add geos-dev --update-cache --virtual build-dependencies --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted \
-    && git clone https://github.com/SWI-Prolog/swipl-devel \
-    && cd swipl-devel && ./prepare --yes && ./configure && make && make install \
+    && curl -O http://www.swi-prolog.org/download/devel/src/swipl-7.5.6.tar.gz \
+    && echo "47c31d4d3140e96706295555b01916dd7bde6c4151c80515a48e7aabfc747288  swipl-7.5.6.tar.gz" >> swipl-7.5.6.tar.gz-CHECKSUM \
+    && sha256sum -c swipl-7.5.6.tar.gz-CHECKSUM \
+    && tar -xzf swipl-7.5.6.tar.gz \
+    && cd swipl-7.5.6 && ./configure && make && make install \
     && cd packages && ./configure && make && make install \
     && apk del build-dependencies \
-    && cd ../.. && rm -rf swipl-devel
+    && cd ../.. && rm -rf swipl-7.5.6.tar.gz swipl-7.5.6.tar.gz-CHECKSUM swipl-7.5.6
 CMD ["swipl"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
 FROM alpine
 LABEL maintainer "Dave Curylo <dave@curylo.org>, Michael Hendricks <michael@ndrix.org>"
-RUN apk --update add --no-cache curl libarchive readline pcre gmp libressl libedit zlib db unixodbc libuuid \
-    && apk --update add --no-cache --virtual build-dependencies bash alpine-sdk autoconf libarchive-dev gmp-dev pcre-dev readline-dev libedit-dev libressl-dev zlib-dev db-dev unixodbc-dev linux-headers \
+RUN SWIPL_VER=7.5.6 && \
+    SWIPL_CHECKSUM=47c31d4d3140e96706295555b01916dd7bde6c4151c80515a48e7aabfc747288 \
+    && apk --update add --no-cache curl libarchive readline pcre gmp libressl libedit zlib db unixodbc libuuid \
+    && apk --update add --no-cache --virtual build-dependencies bash alpine-sdk autoconf libarchive-dev gmp-dev pcre-dev readline-dev libedit-dev libressl-dev zlib-dev db-dev unixodbc-dev util-linux-dev linux-headers \
     && apk add geos-dev --update-cache --virtual build-dependencies --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --allow-untrusted \
-    && curl -O http://www.swi-prolog.org/download/devel/src/swipl-7.5.6.tar.gz \
-    && echo "47c31d4d3140e96706295555b01916dd7bde6c4151c80515a48e7aabfc747288  swipl-7.5.6.tar.gz" >> swipl-7.5.6.tar.gz-CHECKSUM \
-    && sha256sum -c swipl-7.5.6.tar.gz-CHECKSUM \
-    && tar -xzf swipl-7.5.6.tar.gz \
-    && cd swipl-7.5.6 && ./configure && make && make install \
+    && curl -O http://www.swi-prolog.org/download/devel/src/swipl-$SWIPL_VER.tar.gz \
+    && echo "$SWIPL_CHECKSUM  swipl-$SWIPL_VER.tar.gz" >> swipl-$SWIPL_VER.tar.gz-CHECKSUM \
+    && sha256sum -c swipl-$SWIPL_VER.tar.gz-CHECKSUM \
+    && tar -xzf swipl-$SWIPL_VER.tar.gz \
+    && cd swipl-$SWIPL_VER && ./configure && make && make install \
     && cd packages && ./configure && make && make install \
     && apk del build-dependencies \
-    && cd ../.. && rm -rf swipl-7.5.6.tar.gz swipl-7.5.6.tar.gz-CHECKSUM swipl-7.5.6
+    && cd ../.. && rm -rf swipl-$SWIPL_VER.tar.gz swipl-$SWIPL_VER.tar.gz-CHECKSUM swipl-$SWIPL_VER
 CMD ["swipl"]


### PR DESCRIPTION
This Dockerfile builds a swipl environment from source based on Alpine and musl, with a resulting image size of about 34 MiB.  By comparison, the current image is about 264 MiB.  The smaller size is due to
* smaller base image (Alpine is 5 MiB)
* efficient cleanup of build packages using Alpines `apk --virtual` option
* recently added support for musl instead of glibc (thanks @JanWielemaker !)

This image builds and installs all modules, and I've tested it successfully running pengines, although it likely needs more testing before making this official.  It may also need a little modification of the `build` configuration file to ensure the same support as the current image.